### PR TITLE
Integrate the Blake2 implementation from libcrux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,6 +2047,7 @@ dependencies = [
  "rosenpass-util",
  "sha3",
  "static_assertions",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 

--- a/ciphers/Cargo.toml
+++ b/ciphers/Cargo.toml
@@ -10,14 +10,12 @@ repository = "https://github.com/rosenpass/rosenpass"
 readme = "readme.md"
 
 [features]
-#default = ["experiment_libcrux_all"]
-
 experiment_libcrux_all = [
     "experiment_libcrux_blake2",
     "experiment_libcrux_chachapoly",
     "experiment_libcrux_kyber",
 ]
-experiment_libcrux_blake2 = ["dep:libcrux-blake2"]
+experiment_libcrux_blake2 = ["dep:libcrux-blake2", "dep:thiserror"]
 experiment_libcrux_chachapoly = ["dep:libcrux-chacha20poly1305", "dep:libcrux"]
 experiment_libcrux_kyber = ["dep:libcrux-ml-kem", "dep:rand"]
 
@@ -39,6 +37,7 @@ libcrux-blake2 = { workspace = true, optional = true }
 libcrux-ml-kem = { workspace = true, optional = true, features = ["kyber"] }
 sha3 = { workspace = true }
 rand = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/ciphers/src/subtle/keyed_hash.rs
+++ b/ciphers/src/subtle/keyed_hash.rs
@@ -30,8 +30,10 @@ impl KeyedHashInstance<KEY_LEN, HASH_LEN> for KeyedHash {
         out: &mut [u8; HASH_LEN],
     ) -> Result<(), Self::Error> {
         match self {
-            Self::KeyedShake256(h) => h.keyed_hash(key, data, out),
-            Self::IncorrectHmacBlake2b(h) => h.keyed_hash(key, data, out),
-        }
+            Self::KeyedShake256(h) => h.keyed_hash(key, data, out)?,
+            Self::IncorrectHmacBlake2b(h) => h.keyed_hash(key, data, out)?,
+        };
+
+        Ok(())
     }
 }

--- a/ciphers/src/subtle/libcrux/blake2b.rs
+++ b/ciphers/src/subtle/libcrux/blake2b.rs
@@ -3,8 +3,11 @@ use rosenpass_cipher_traits::primitives::KeyedHash;
 
 use libcrux_blake2::Blake2bBuilder;
 
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("internal error")]
     InternalError,
+    #[error("data is too long")]
     DataTooLong,
 }
 


### PR DESCRIPTION
The PR makes the rest of the code use the already present blake2 implementation from libcrux, if the respective feature flag is set.