### PR TITLE
Fix the Doctests

### DIFF
--- a/ciphers/src/hash_domain.rs
+++ b/ciphers/src/hash_domain.rs
@@ -1,7 +1,7 @@
 //!
 //!```rust
 //! # use rosenpass_ciphers::hash_domain::{HashDomain, HashDomainNamespace, SecretHashDomain, SecretHashDomainNamespace};
-//! use rosenpass_ciphers::keyed_hash::KeyedHash;
+//! use rosenpass_ciphers::KeyedHash;
 //! use rosenpass_secret_memory::Secret;
 //! # rosenpass_secret_memory::secret_policy_use_only_malloc_secrets();
 //!

--- a/ciphers/src/subtle/custom/incorrect_hmac_blake2b.rs
+++ b/ciphers/src/subtle/custom/incorrect_hmac_blake2b.rs
@@ -30,14 +30,15 @@ pub const HASH_LEN: usize = 32;
 ///
 /// # Examples
 ///```rust
-/// # use rosenpass_ciphers::subtle::incorrect_hmac_blake2b::hash;
+/// # use rosenpass_ciphers::subtle::custom::incorrect_hmac_blake2b::IncorrectHmacBlake2bCore;
+/// use rosenpass_cipher_traits::primitives::KeyedHashTo;
 /// use rosenpass_to::To;
 /// let key: [u8; 32] = [0; 32];
 /// let data: [u8; 32] = [255; 32];
 /// // buffer for the hash output
 /// let mut hash_data: [u8; 32] = [0u8; 32];
 ///
-/// assert!(hash(&key, &data).to(&mut hash_data).is_ok(), "Hashing has to return OK result");
+/// assert!(IncorrectHmacBlake2bCore::keyed_hash_to(&key, &data).to(&mut hash_data).is_ok(), "Hashing has to return OK result");
 /// # let expected_hash: &[u8] = &[5, 152, 135, 141, 151, 106, 147, 8, 220, 95, 38, 66, 29, 33, 3,
 /// 104, 250, 114, 131, 119, 27, 56, 59, 44, 11, 67, 230, 113, 112, 20, 80, 103];
 /// # assert_eq!(hash_data, expected_hash);

--- a/ciphers/src/subtle/rust_crypto/chacha20poly1305_ietf.rs
+++ b/ciphers/src/subtle/rust_crypto/chacha20poly1305_ietf.rs
@@ -86,13 +86,13 @@ impl Aead<KEY_LEN, NONCE_LEN, TAG_LEN> for ChaCha20Poly1305 {
 ///
 /// # Examples
 ///```rust
-/// # use rosenpass_ciphers::subtle::chacha20poly1305_ietf::{encrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
+/// # use rosenpass_ciphers::subtle::rust_crypto::chacha20poly1305_ietf::{encrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
 ///
 /// const PLAINTEXT_LEN: usize = 43;
 /// let plaintext = "post-quantum cryptography is very important".as_bytes();
 /// assert_eq!(PLAINTEXT_LEN, plaintext.len());
-/// let key: &[u8] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
-/// let nonce: &[u8] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
+/// let key: &[u8; KEY_LEN] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
+/// let nonce: &[u8; NONCE_LEN] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
 /// let additional_data: &[u8] = "the encrypted message is very important".as_bytes();
 /// let mut ciphertext_buffer = [0u8;PLAINTEXT_LEN + TAG_LEN];
 ///
@@ -125,7 +125,7 @@ pub fn encrypt(
 ///
 /// # Examples
 ///```rust
-/// # use rosenpass_ciphers::subtle::chacha20poly1305_ietf::{decrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
+/// # use rosenpass_ciphers::subtle::rust_crypto::chacha20poly1305_ietf::{decrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
 /// let ciphertext: &[u8] = &[239, 104, 148, 202, 120, 32, 77, 27, 246, 206, 226, 17,
 /// 83, 78, 122, 116, 187, 123, 70, 199, 58, 130, 21, 1, 107, 230, 58, 77, 18, 152, 31, 159, 80,
 /// 151, 72, 27, 236, 137, 60, 55, 180, 31, 71, 97, 199, 12, 60, 155, 70, 221, 225, 110, 132, 191,
@@ -133,8 +133,8 @@ pub fn encrypt(
 /// const PLAINTEXT_LEN: usize = 43;
 /// assert_eq!(PLAINTEXT_LEN + TAG_LEN, ciphertext.len());
 ///
-/// let key: &[u8] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
-/// let nonce: &[u8] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
+/// let key: &[u8; KEY_LEN] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
+/// let nonce: &[u8; NONCE_LEN] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
 /// let additional_data: &[u8] = "the encrypted message is very important".as_bytes();
 /// let mut plaintext_buffer = [0u8; PLAINTEXT_LEN];
 ///

--- a/ciphers/src/subtle/rust_crypto/keyed_shake256.rs
+++ b/ciphers/src/subtle/rust_crypto/keyed_shake256.rs
@@ -23,8 +23,8 @@ impl<const KEY_LEN: usize, const HASH_LEN: usize> KeyedHash<KEY_LEN, HASH_LEN>
     /// TODO: Example/Test
     /// #Examples
     /// ```rust
-    /// # use rosenpass_ciphers::subtle::keyed_shake256::SHAKE256Core;
-    /// use rosenpass_cipher_traits::KeyedHash;
+    /// # use rosenpass_ciphers::subtle::rust_crypto::keyed_shake256::SHAKE256Core;
+    /// use rosenpass_cipher_traits::primitives::KeyedHash;
     /// const KEY_LEN: usize = 32;
     /// const HASH_LEN: usize = 32;
     /// let key: [u8; 32] = [0; KEY_LEN];
@@ -78,11 +78,11 @@ impl<const KEY_LEN: usize, const HASH_LEN: usize> Default for SHAKE256Core<KEY_L
 
 /// TODO use inferred hash somehow here
 /// ```rust
-/// # use rosenpass_ciphers::subtle::keyed_shake256::{SHAKE256};
-/// use rosenpass_cipher_traits::KeyedHashInstance;
+/// # use rosenpass_ciphers::subtle::rust_crypto::keyed_shake256::{SHAKE256};
+/// use rosenpass_cipher_traits::primitives::KeyedHashInstance;
 /// const KEY_LEN: usize = 32;
 /// const HASH_LEN: usize = 32;
-/// let key: [u8; 32] = [0; KEY_LEN];
+/// let key: [u8; KEY_LEN] = [0; KEY_LEN];
 /// let data: [u8; 32] = [255; 32]; // arbitrary data, could also be longer
 /// // buffer for the hash output
 /// let mut hash_data: [u8; 32] = [0u8; HASH_LEN];
@@ -98,7 +98,7 @@ pub type SHAKE256<const KEY_LEN: usize, const HASH_LEN: usize> =
 /// TODO: Documentation and more interesting test
 /// ```rust
 /// # use rosenpass_ciphers::subtle::keyed_shake256::{SHAKE256_32};
-/// use rosenpass_cipher_traits::KeyedHashInstance;
+/// use rosenpass_cipher_traits::primitives::KeyedHashInstance;
 /// const KEY_LEN: usize = 32;
 /// const HASH_LEN: usize = 32;
 /// let key: [u8; 32] = [0; KEY_LEN];

--- a/ciphers/src/subtle/rust_crypto/xchacha20poly1305_ietf.rs
+++ b/ciphers/src/subtle/rust_crypto/xchacha20poly1305_ietf.rs
@@ -87,12 +87,12 @@ impl Aead<KEY_LEN, NONCE_LEN, TAG_LEN> for XChaCha20Poly1305 {
 ///
 /// # Examples
 ///```rust
-/// # use rosenpass_ciphers::subtle::xchacha20poly1305_ietf::{encrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
+/// # use rosenpass_ciphers::subtle::rust_crypto::xchacha20poly1305_ietf::{encrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
 /// const PLAINTEXT_LEN: usize = 43;
 /// let plaintext = "post-quantum cryptography is very important".as_bytes();
 /// assert_eq!(PLAINTEXT_LEN, plaintext.len());
-/// let key: &[u8] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
-/// let nonce: &[u8] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
+/// let key: &[u8; KEY_LEN] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
+/// let nonce: &[u8; NONCE_LEN] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
 /// let additional_data: &[u8] = "the encrypted message is very important".as_bytes();
 /// let mut ciphertext_buffer = [0u8; NONCE_LEN + PLAINTEXT_LEN + TAG_LEN];
 ///
@@ -114,7 +114,7 @@ pub fn encrypt(
     plaintext: &[u8],
 ) -> anyhow::Result<()> {
     XChaCha20Poly1305
-        .encrypt(ciphertext, key, nonce, ad, plaintext)
+        .encrypt_with_nonce_in_ctxt(ciphertext, key, nonce, ad, plaintext)
         .map_err(anyhow::Error::from)
 }
 
@@ -130,7 +130,7 @@ pub fn encrypt(
 ///
 /// # Examples
 ///```rust
-/// # use rosenpass_ciphers::subtle::xchacha20poly1305_ietf::{decrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
+/// # use rosenpass_ciphers::subtle::rust_crypto::xchacha20poly1305_ietf::{decrypt, TAG_LEN, KEY_LEN, NONCE_LEN};
 /// let ciphertext: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 /// # 0, 0, 0, 0, 8, 241, 229, 253, 200, 81, 248, 30, 183, 149, 134, 168, 149, 87, 109, 49, 159, 108,
 /// # 206, 89, 51, 232, 232, 197, 163, 253, 254, 208, 73, 76, 253, 13, 247, 162, 133, 184, 177, 44,
@@ -139,8 +139,8 @@ pub fn encrypt(
 /// const PLAINTEXT_LEN: usize = 43;
 /// assert_eq!(PLAINTEXT_LEN + TAG_LEN + NONCE_LEN, ciphertext.len());
 ///
-/// let key: &[u8] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
-/// let nonce: &[u8] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
+/// let key: &[u8; KEY_LEN] = &[0u8; KEY_LEN]; // THIS IS NOT A SECURE KEY
+/// let nonce: &[u8; NONCE_LEN] = &[0u8; NONCE_LEN]; // THIS IS NOT A SECURE NONCE
 /// let additional_data: &[u8] = "the encrypted message is very important".as_bytes();
 /// let mut plaintext_buffer = [0u8; PLAINTEXT_LEN];
 ///


### PR DESCRIPTION
The previous PRs moved around a lot of types and modules, which inadvertently broke some of the doctests. This PR fixes them. The tests in the RustCrypto SHAKE256 crate still fail, but that has already been the case before.